### PR TITLE
Debug prints and Client Fixes

### DIFF
--- a/Client.cpp
+++ b/Client.cpp
@@ -11,12 +11,21 @@
 
 #include "libsrvcli.hpp"
 
+#ifndef DEBUG_PRINTS
+#define DEBUG_PRINTS 0
+#endif
+
+#if DEBUG_PRINTS
+#define perror(msg) perror(msg)
+#else
+#define perror(msg) 
+#endif
+
 using namespace std;
 
-Client::Client(void (*handler)(int), ConnectionConfig config)
+Client::Client(ConnectionConfig config)
 {
     this->config = config;
-    connectionHandler = handler; 
 }
 
 Client::~Client()
@@ -24,7 +33,7 @@ Client::~Client()
     disconnect();
 }
 
-int Client::establishConnection()
+int Client::connect()
 {
     int yes = 1, rv;
     struct addrinfo hints, *servinfo, *p; 
@@ -37,7 +46,7 @@ int Client::establishConnection()
 
 	if ((rv = getaddrinfo(config.getIP().c_str(), config.getPort().c_str(), &hints, &servinfo)) != 0)
     {
-        cerr << "getaddrinfo:" << gai_strerror(rv) << endl;
+        perror(gai_strerror(rv));
         return -1;
 	}
 
@@ -59,19 +68,19 @@ int Client::establishConnection()
 
     if (p == NULL)
     {
-        cerr << "client: failed to connect" << endl;
+        perror("client: failed to connect");
         return -1;
     }
 
     inet_ntop(p->ai_family, getInAddr((struct sockaddr *)p->ai_addr), s, sizeof s);
     
-    cout << "client: establishing connection to " << s << endl;
+#if DEBUG_PRINTS
+    cout << "client: establishing connectioj to " << s << endl;
+#endif
 
 	freeaddrinfo(servinfo); // all done with this structure
 
-    connectionHandler(sockfd);
-    
-    return 0;
+    return sockfd;
 }
 
 void Client::disconnect()

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
-CC=g++ 
-CFLAGS=-fPIC -c
-LDFLAGS=-Iinclude -lpthread
+CC:=g++ 
+CFLAGS:=-fPIC -c
+LDFLAGS:=-Iinclude -lpthread
+
+ifdef $(DEBUG)
+CFLAGS += -DDEBUG_PRINTS=$(DEBUG)
+endif
 
 libsrvcli.so: server.o client.o
 	$(CC) -shared -o libsrvcli.so server.o client.o $(LDFLAGS)

--- a/README.md
+++ b/README.md
@@ -65,7 +65,16 @@ void makeRequest(int sockfd)
 int main()
 {
 	Client* cli = new Client(&makeRequests, conConfig);
-	if (cli->establishConnection() == -1)
+	int sockfd = cli->connect();
+	if (sockfd == -1)
     	cout << "Error in connecting to node server" << endl;
+	
+	makeRequest(sockfd);
+    
+    //...
+
+    cli->disconnect();
+
+    return 0;
 }
 ```

--- a/Server.cpp
+++ b/Server.cpp
@@ -14,6 +14,16 @@
 #define MAX_CONNECTIONS 100
 #define BACKLOG_CONNECTIONS 20 
 
+#ifndef DEBUG_PRINTS
+#define DEBUG_PRINTS 0
+#endif
+
+#if DEBUG_PRINTS
+#define perror(msg) perror(msg)
+#else
+#define perror(msg) 
+#endif
+
 using namespace std;
 
 Server::Server(void (*handler)(int), ConnectionConfig config)
@@ -38,7 +48,7 @@ int Server::start() {
 
 	if ((rv = getaddrinfo(NULL, config.getPort().c_str(), &hints, &servinfo)) != 0)
     {
-        cerr << "getaddrinfo:" << gai_strerror(rv) << endl;
+        perror(gai_strerror(rv));
         return -1;
 	}
 
@@ -125,7 +135,9 @@ void Server::acceptConnections()
 
         inet_ntop(their_addr.ss_family, getInAddr((struct sockaddr *)&their_addr), s, sizeof s);
 
+#if DEBUG_PRINTS
         cout << "server: got connection from" << s << endl;
+#endif
 
         connectionsBuffer.enqueue(newfd);
     }

--- a/include/libsrvcli.hpp
+++ b/include/libsrvcli.hpp
@@ -35,9 +35,9 @@ class Client
 
 public:
 
-    Client(void (*)(int), ConnectionConfig);
+    Client(ConnectionConfig);
     ~Client();
-    int establishConnection();
+    int connect();
     void disconnect();
 
 private:


### PR DESCRIPTION
Debug Prints:
- Add debug compile flag in makefile and source files
- Print only when compiled with DEBUG_PRINTS is 1

Client Fix:
- Remove handler functionality from Client.
- Change establishConnection() to connect() that returns valid socket fd.